### PR TITLE
BLD: Add lapack_lite_module back + support win32noblas

### DIFF
--- a/numpy/linalg/meson.build
+++ b/numpy/linalg/meson.build
@@ -7,15 +7,27 @@ lapack_lite_sources = [
   'lapack_lite/f2c_blas.c',
   'lapack_lite/f2c_config.c',
   'lapack_lite/f2c_lapack.c',
+  'lapack_lite/python_xerbla.c',
 ]
 
+# TODO: ILP64 support
+
+lapack_lite_module_src = ['lapack_litemodule.c']
 _umath_linalg_src = ['umath_linalg.cpp']
+
 if not have_lapack
+  lapack_lite_module_src += lapack_lite_sources
   _umath_linalg_src += lapack_lite_sources
-endif
-if not is_windows
+elif not is_windows
   _umath_linalg_src += ['lapack_lite/python_xerbla.c']
 endif
+
+py.extension_module('lapack_lite',
+  lapack_lite_module_src,
+  dependencies: [np_core_dep, blas_dep, lapack_dep],
+  install: true,
+  subdir: 'numpy/linalg',
+)
 
 py.extension_module('_umath_linalg',
   _umath_linalg_src,

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -207,6 +207,7 @@ PRIVATE_BUT_PRESENT_MODULES = ['numpy.' + s for s in [
     "lib.ufunclike",
     "lib.user_array",  # note: not in np.lib, but probably should just be deleted
     "lib.utils",
+    "linalg.lapack_lite",
     "linalg.linalg",
     "ma.core",
     "ma.testutils",


### PR DESCRIPTION
Some of the tests still required the lapack_lite module, so this sub-PR adds it back. There was also a failure on win32noblas where xerbla was missing. I think this will fix that too.